### PR TITLE
Overhauling argument behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@
 .vs
 Debug
 Release
+vcpkg
 vcpkg_installed
 *.user

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@
 Debug
 Release
 vcpkg
+.vscode
 vcpkg_installed
 *.user

--- a/README.md
+++ b/README.md
@@ -37,11 +37,9 @@ You should now be able to build d2mapapi.sln
 
 ## Usage
 
-d2mapapi.exe DIABLO2_PATH \[OPTIONAL_ARGUMENTS\]
-
-Examples:
+Syntax:
 ```
-d2mapapi.exe {diablo2dir} [optionalArguments]
+d2mapapi.exe {pathToDiablo2} [optionalArguments]
 ```
 
 ### Optional Arguments

--- a/README.md
+++ b/README.md
@@ -37,15 +37,20 @@ You should now be able to build d2mapapi.sln
 
 ## Usage
 
-d2mapapi.exe DIABLO2_PATH \[ADDRESS_OVERRIDE\]
+d2mapapi.exe DIABLO2_PATH \[OPTIONAL_ARGUMENTS\]
 
 Examples:
 ```
-d2mapapi.exe "C:\Diablo II1.13c"
-d2mapapi.exe "C:\Diablo II1.13c" "0.0.0.0"
+d2mapapi.exe {diablo2dir} [optionalArguments]
 ```
 
-Starts the webserver
+### Optional Arguments
+    * -i or --ip
+        specify an IP address to use instead of localhost. ex: `-i 192.168.0.1` OR `--ip=192.168.0.1`";
+    * -p or --port
+        specify n port address to use instead of the default 8080. ex: `-p 8080` OR `--port=8080`";
+    * -h or --help
+        display usage information
 
 ## Running in Docker
 
@@ -62,7 +67,7 @@ WORKDIR /app
 # d2mapapi should be in the same folder as your dockerfile
 COPY ./d2mapapi .
 EXPOSE 8080
-CMD ["wine", "d2mapapi.exe", "/app/game", "0.0.0.0"]
+CMD ["wine", "d2mapapi.exe", "/app/game", "--ip=0.0.0.0"]
 ```
 
 [Download the latest release](https://github.com/rmilejcz/d2mapapi/releases)

--- a/README.md
+++ b/README.md
@@ -5,16 +5,35 @@ A diablo 2 1.13C installation is required, but this API should work for all vers
 
 ## Installation
 
-Download & install vcpkg https://github.com/microsoft/vcpkg (don't forget to add to path)
+First install [vcpkg](https://github.com/microsoft/vcpkg)
 
-Dependencies should now be installed and included for you when building from source.
+### Windows
+```
+git clone https://github.com/microsoft/vcpkg
+.\vcpkg\bootstrap-vcpkg.bat
+```
 
-If required, manually install and include these dependences:
+### Unix
+```
+git clone https://github.com/microsoft/vcpkg
+.\vcpkg\bootstrap-vcpkg.sh
+```
+
+The binary will be located here `.\vcpkg\vcpkg`, make sure to include this in your path and restart your shell. Once done setup a vcpkg integration by running:
+
+```
+vcpkg integrate install
+```
+
+If you are using Visual Studio to build this project, vcpkg dependencies will be automatically installed and included to this repository. If not, you will need to manually fetch and include the following packages:
+
 ```
 vcpkg install boost-uuid
 vcpkg install restinio
 vcpkg install json-dto
 ```
+
+You should now be able to build d2mapapi.sln
 
 ## Usage
 
@@ -46,7 +65,7 @@ EXPOSE 8080
 CMD ["wine", "d2mapapi.exe", "/app/game", "0.0.0.0"]
 ```
 
-[Download the latest release](https://github.com/jcageman/d2mapapi/releases)
+[Download the latest release](https://github.com/rmilejcz/d2mapapi/releases)
 
 Place the d2mapapi folder the dockerfile in the same folder, and navigate their via command line then run `docker build -t d2mapapi .`
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,20 @@ Syntax:
 d2mapapi.exe {pathToDiablo2} [optionalArguments]
 ```
 
-### Optional Arguments
+#### Optional Arguments
     * -i or --ip
         specify an IP address to use instead of localhost. ex: `-i 192.168.0.1` OR `--ip=192.168.0.1`";
     * -p or --port
         specify n port address to use instead of the default 8080. ex: `-p 8080` OR `--port=8080`";
     * -h or --help
         display usage information
+
+#### Examples
+```
+d2mapapi.exe "C:\Diablo II1.13c"
+d2mapapi.exe "C:\Diablo II1.13c" --ip=0.0.0.0 --port=88
+d2mapapi.exe "C:\Diablo II1.13c" --port=80
+```
 
 ## Running in Docker
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/microsoft/vcpkg
 .\vcpkg\bootstrap-vcpkg.sh
 ```
 
-The binary will be located here `.\vcpkg\vcpkg`, make sure to include this in your path and restart your shell. Once done setup a vcpkg integration by running:
+The binary will be located here `.\vcpkg\vcpkg`, make sure to include the absolute path to this in your system path environment variable and restart your shell. Once done setup a vcpkg integration by running:
 
 ```
 vcpkg integrate install

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ EXPOSE 8080
 CMD ["wine", "d2mapapi.exe", "/app/game", "--ip=0.0.0.0"]
 ```
 
-[Download the latest release](https://github.com/rmilejcz/d2mapapi/releases)
+[Download the latest release](https://github.com/jcageman/d2mapapi/releases)
 
 Place the d2mapapi folder the dockerfile in the same folder, and navigate their via command line then run `docker build -t d2mapapi .`
 

--- a/d2mapapi/Helpers.cpp
+++ b/d2mapapi/Helpers.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+#include <string>
+#include <regex>
+
+std::string extractArg(std::string arg) {
+	std::regex rgx("--\\w+=(.+)");
+	std::smatch match;
+	if (std::regex_search(arg, match, rgx)) {
+		return match[1];
+	}
+	else {
+		std::cerr << "Failed to extract value in argument: " + arg;
+		return "";
+	}
+}
+
+void printHelp() {
+	std::cerr << "Usage: program.exe {diablo2dir} [optionalArguments]\n";
+	std::cerr << "\t-i or --ip\n\t\tspecify an IP address to use instead of localhost.\n\t\tex: -i 192.168.0.1 OR --ip=192.168.0.1\n";
+	std::cerr << "\t-p or --port\n\t\tspecify an port address to use instead of the default 8080.\n\t\tex: -p 8080 OR --port=8080\n";
+	std::cerr << "\t-h or --help\n\t\tprints this usage information\n";
+	std::cerr << "Example: program.exe \"C:\\Diablo II1.13c\"\nor\nExample: program.exe \"C:\\Diablo II1.13c\" -i 0.0.0.0 -p 8888";
+}

--- a/d2mapapi/Helpers.h
+++ b/d2mapapi/Helpers.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+
+void printHelp();
+std::string extractArg(std::string arg);

--- a/d2mapapi/d2mapapi.vcxproj
+++ b/d2mapapi/d2mapapi.vcxproj
@@ -21,12 +21,14 @@
     <ClCompile Include="NewSessionDto.cpp" />
     <ClCompile Include="Session.cpp" />
     <ClCompile Include="SessionDto.cpp" />
+    <ClCompile Include="Helpers.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CollisionMap.h" />
     <ClInclude Include="D2Map.h" />
     <ClInclude Include="D2Ptrs.h" />
     <ClInclude Include="D2Structs.h" />
+    <ClInclude Include="Helpers.h" />
     <ClInclude Include="MapDto.h" />
     <ClInclude Include="MapRequestHandler.h" />
     <ClInclude Include="Offset.h" />

--- a/d2mapapi/main.cpp
+++ b/d2mapapi/main.cpp
@@ -8,19 +8,21 @@
 
 
 int main( int argc, const char* argv[] ) {
-
+    int i;
 	// Check command line arguments.
 	if (argc < 2)
 	{
-		std::cerr << "Usage: program.exe {diablo2dir} [addressOverride]\n";
-		std::cerr << "Example: program.exe \"C:\\Diablo II1.13c\"\nor\nExample: program.exe \"C:\\Diablo II1.13c\" 0.0.0.0";
+		std::cerr << "Usage: program.exe {diablo2dir} [optionalArguments]\n";
+		std::cerr << "\t-i or --ip\n\t\tspecify an IP address to use instead of localhost.\n\t\tex: -i 192.168.0.1 OR --ip=192.168.0.1\n";
+		std::cerr << "\t-p or --port\n\t\tspecify an port address to use instead of the default 8080.\n\t\tex: -p 8080 OR --port=8080\n";
+		std::cerr << "\t-h or --help\n\t\tprints this usage information\n";
+		std::cerr << "Example: program.exe \"C:\\Diablo II1.13c\"\nor\nExample: program.exe \"C:\\Diablo II1.13c\" -i 0.0.0.0 -p 8888";
 		return 1;
 	}
 
 	using namespace std::chrono;
 	try
 	{
-		
 		init( argv[1] );
 		
 		using traits_t =
@@ -30,14 +32,59 @@ int main( int argc, const char* argv[] ) {
 			router_t >;
 
 		std::string address = "localhost";
+		std::uint16_t port = 8080;
 
-		if (argc == 3) {
-			address = argv[2];
+		// handle args in this loop:
+		for(i=2; i<argc; ++i)
+		{	
+			std::regex rgx("--\\w+=(.+)");
+			std::smatch match;
+			std::string tmpArg = argv[i];
+
+			if (tmpArg == "-h" || tmpArg == "--help")
+			{
+				std::cout << "Usage: program.exe {diablo2dir} [optionalArguments]\n";
+				std::cout << "\t -i or --ip\n\t\tspecify an IP address to use instead of localhost.\n\t\tex: -i 192.168.0.1 OR --ip=192.168.0.1\n";
+				std::cout << "\t-p or --port\n\t\tspecify an port address to use instead of the default 8080.\n\t\tex: -p 8080 OR --port=8080";
+				return 0;
+			}
+			if (tmpArg == "-i") 
+			{
+				address = argv[i + 1];
+			}
+			if (tmpArg == "-p")
+			{
+				char *end;
+				errno = 0;
+				long val = strtol(argv[i + 1], &end, 10);
+				if (errno || end == argv[i + 1] || *end != '\0' || val < 0 || val >= 0x10000) {
+					std::cerr << "Failed to convert port argument to uint16 from string, ensure the value passed is a valid integer\n";
+					return 1;
+				}
+				port = (uint16_t)val;
+			}
+			if (tmpArg.find("--ip") != std::string::npos)
+			{	
+				if (std::regex_search(tmpArg, match, rgx)) {
+					address = match[1];
+				} else {
+					std::cerr << "Failed to find valid IP address in argument --ip, using localhost";
+				}
+			}
+			if (tmpArg.find("--port") != std::string::npos) 
+			{
+				if (std::regex_search(tmpArg, match, rgx)) {
+					port = std::stoi(match[1]);
+				} else {
+					std::cerr << "Failed to find valid port in argument --port, using 8080";
+				}
+			}
 		}
 
 		restinio::run(
 			restinio::on_this_thread< traits_t >()
 			.address( address )
+			.port( port )
 			.request_handler( map::create_server_handler() )
 			.read_next_http_message_timelimit( 10s )
 			.write_http_response_timelimit( 1s )

--- a/d2mapapi/main.cpp
+++ b/d2mapapi/main.cpp
@@ -4,19 +4,15 @@
 
 #include "D2Map.h"
 #include "ServerHandler.h"
-
-
+#include "Helpers.h"
 
 int main( int argc, const char* argv[] ) {
     int i;
+
 	// Check command line arguments.
 	if (argc < 2)
 	{
-		std::cerr << "Usage: program.exe {diablo2dir} [optionalArguments]\n";
-		std::cerr << "\t-i or --ip\n\t\tspecify an IP address to use instead of localhost.\n\t\tex: -i 192.168.0.1 OR --ip=192.168.0.1\n";
-		std::cerr << "\t-p or --port\n\t\tspecify an port address to use instead of the default 8080.\n\t\tex: -p 8080 OR --port=8080\n";
-		std::cerr << "\t-h or --help\n\t\tprints this usage information\n";
-		std::cerr << "Example: program.exe \"C:\\Diablo II1.13c\"\nor\nExample: program.exe \"C:\\Diablo II1.13c\" -i 0.0.0.0 -p 8888";
+		printHelp();
 		return 1;
 	}
 
@@ -37,46 +33,44 @@ int main( int argc, const char* argv[] ) {
 		// handle args in this loop:
 		for(i=2; i<argc; ++i)
 		{	
-			std::regex rgx("--\\w+=(.+)");
-			std::smatch match;
 			std::string tmpArg = argv[i];
+			std::string argVal;
 
 			if (tmpArg == "-h" || tmpArg == "--help")
 			{
-				std::cout << "Usage: program.exe {diablo2dir} [optionalArguments]\n";
-				std::cout << "\t -i or --ip\n\t\tspecify an IP address to use instead of localhost.\n\t\tex: -i 192.168.0.1 OR --ip=192.168.0.1\n";
-				std::cout << "\t-p or --port\n\t\tspecify an port address to use instead of the default 8080.\n\t\tex: -p 8080 OR --port=8080";
+				printHelp();
 				return 0;
 			}
+
 			if (tmpArg == "-i") 
-			{
 				address = argv[i + 1];
-			}
+
 			if (tmpArg == "-p")
 			{
-				char *end;
-				errno = 0;
-				long val = strtol(argv[i + 1], &end, 10);
-				if (errno || end == argv[i + 1] || *end != '\0' || val < 0 || val >= 0x10000) {
-					std::cerr << "Failed to convert port argument to uint16 from string, ensure the value passed is a valid integer\n";
+				std::string tmpPort = argv[i + 1];
+				port = std::stoi(tmpPort);
+			}
+
+			if (tmpArg.find("--ip") != std::string::npos)
+			{
+				argVal = extractArg(tmpArg);
+				if (argVal == "") {
 					return 1;
 				}
-				port = (uint16_t)val;
-			}
-			if (tmpArg.find("--ip") != std::string::npos)
-			{	
-				if (std::regex_search(tmpArg, match, rgx)) {
-					address = match[1];
-				} else {
-					std::cerr << "Failed to find valid IP address in argument --ip, using localhost";
+				else {
+					address = argVal;
 				}
 			}
-			if (tmpArg.find("--port") != std::string::npos) 
+
+
+			if (tmpArg.find("--port") != std::string::npos)
 			{
-				if (std::regex_search(tmpArg, match, rgx)) {
-					port = std::stoi(match[1]);
-				} else {
-					std::cerr << "Failed to find valid port in argument --port, using 8080";
+				argVal = extractArg(tmpArg);
+				if (argVal == "") {
+					return 1;
+				}
+				else {
+					port = std::stoi(extractArg(tmpArg));
 				}
 			}
 		}


### PR DESCRIPTION
All optional arguments are now passed canonically as flags in the format `-p` or `--port=` ex:

```
./d2mapapi.exe "C:/Diablo2" --ip=0.0.0.0 --port=88
```

or

```
./d2mapapi.exe "C:/Diablo2" -p 88 -i 0.0.0.0
```

So optional arguments can now be passed with varying degrees of verbosity and in any order.

Arguments are now handled in a loop in main at the start of execution, so implementing future arguments should be simple.

In addition to this I added a help flag which spits out usage information then exits the program with code 0, and also implemented an argument for supplying a port instead of just using the default 8080 from restinio.

Lastly, I cleaned up the installation instructions to provide more specific information on installing vcpkg to manage dependencies.

I've also included the output from my latest build, in the hopes that would host a release on your own branch. If not, I do understand

[d2mapapi.zip](https://github.com/jcageman/d2mapapi/files/7412076/d2mapapi.zip)